### PR TITLE
Include fallback channel headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ erl_crash.dump
 *.log
 log/
 /.elixir_ls
+excoveralls.json

--- a/config/test.exs
+++ b/config/test.exs
@@ -34,6 +34,6 @@ config :turn_junebug_expressway, :rabbitmq,
 
 config :turn_junebug_expressway, :turn,
   base_url: System.get_env("TURN_URL", "https://testapp.turn.io"),
-  outbound_path: System.get_env("TURN_OUTBOUND", "api/whatsapp/channel-id"),
+  event_path: System.get_env("TURN_OUTBOUND", "api/whatsapp/channel-id"),
   inbound_path: System.get_env("TURN_INBOUND", "v1/events"),
   token: System.get_env("TURN_TOKEN", "replaceme")

--- a/lib/turn_junebug_expressway/turn_client.ex
+++ b/lib/turn_junebug_expressway/turn_client.ex
@@ -38,7 +38,11 @@ defmodule TurnJunebugExpressway.TurnClient do
 
   def do_post(client, path, body, headers \\ []) do
     case client
-         |> post(path, body, headers: headers) do
+         |> post(path, body,
+           headers: [
+             {"x-turn-fallback-channel", "1"} | headers
+           ]
+         ) do
       {:ok, %Tesla.Env{status: status}}
       when status in 200..299 ->
         :ok

--- a/test/turn_junebug_expressway/behaviours/client_behaviour_test.exs
+++ b/test/turn_junebug_expressway/behaviours/client_behaviour_test.exs
@@ -1,0 +1,48 @@
+defmodule TurnJunebugExpressway.Behaviours.ClientBehaviourTest do
+  use TurnJunebugExpressway.DataCase
+
+  alias TurnJunebugExpressway.TurnClient
+  alias TurnJunebugExpresswayWeb.Utils
+
+  import Tesla.Mock
+
+  describe "client behaviour" do
+    test "post_event/2 should post to the fallback channel", %{} do
+      mock(fn %{
+                method: :post,
+                url: "https://testapp.turn.io/api/whatsapp/channel-id",
+                body: body,
+                headers: headers
+              } ->
+        assert Jason.decode!(body) == %{"some" => "event"}
+        headers == [{"x-turn-fallback-channel", "1"}]
+        json(%{})
+      end)
+
+      client = TurnClient.client()
+      TurnClient.post_event(client, %{"some" => "event"})
+    end
+
+    test "post_inbound/2 should post to the fallback channel", %{} do
+      mock(fn %{
+                method: :post,
+                url: "https://testapp.turn.io/v1/events",
+                body: body,
+                headers: headers
+              } ->
+        assert Jason.decode!(body) == %{"some" => "inbound"}
+
+        headers == [
+          {"authorization", "Bearer " <> Utils.get_env(:turn, :token)},
+          {"accept", "application/vnd.v1+json"},
+          {"x-turn-fallback-channel", "1"}
+        ]
+
+        json(%{})
+      end)
+
+      client = TurnClient.client()
+      TurnClient.post_inbound(client, %{"some" => "inbound"})
+    end
+  end
+end


### PR DESCRIPTION
This will make turn forward the same header to the webhooks so that we can identity which events come from the fallback channel, see the note here: https://whatsapp.praekelt.org/docs/index.html#events