### PR TITLE
Add rapidpro client to send inbounds

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,7 +14,8 @@ config :turn_junebug_expressway, TurnJunebugExpresswayWeb.Endpoint,
   watchers: []
 
 config :turn_junebug_expressway,
-  turn_client: TurnJunebugExpressway.TurnClient
+  turn_client: TurnJunebugExpressway.TurnClient,
+  rapidpro_client: TurnJunebugExpressway.RapidproClient
 
 # ## SSL Support
 #
@@ -62,3 +63,6 @@ config :turn_junebug_expressway, :turn,
   outbound_path: System.get_env("TURN_OUTBOUND", "api/whatsapp/channel-id"),
   inbound_path: System.get_env("TURN_INBOUND", "v1/events"),
   token: System.get_env("TURN_TOKEN", "replaceme")
+
+config :turn_junebug_expressway, :rapidpro,
+  base_url: System.get_env("RAPIDPRO_URL", "https://test-rp.com/c/wa/channel-id/receive")

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,7 +18,8 @@ config :turn_junebug_expressway, TurnJunebugExpresswayWeb.Endpoint,
   url: [host: System.get_env("HOST"), port: 80]
 
 config :turn_junebug_expressway,
-  turn_client: TurnJunebugExpressway.TurnClient
+  turn_client: TurnJunebugExpressway.TurnClient,
+  rapidpro_client: TurnJunebugExpressway.RapidproClient
 
 # Do not print debug messages in production
 config :logger, level: :info
@@ -79,3 +80,6 @@ config :turn_junebug_expressway, :turn,
   event_path: System.get_env("TURN_OUTBOUND", "api/whatsapp/channel-id"),
   inbound_path: System.get_env("TURN_INBOUND", "v1/events"),
   token: System.get_env("TURN_TOKEN", "replaceme")
+
+config :turn_junebug_expressway, :rapidpro,
+  base_url: System.get_env("RAPIDPRO_URL", "https://test-rp.com/c/wa/channel-id/receive")

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,8 @@ config :turn_junebug_expressway, TurnJunebugExpresswayWeb.Endpoint,
   server: false
 
 config :turn_junebug_expressway,
-  turn_client: TurnJunebugExpressway.Backends.ClientMock
+  turn_client: TurnJunebugExpressway.Backends.ClientMock,
+  rapidpro_client: TurnJunebugExpressway.Backends.ClientMock
 
 # Print only warnings and errors during test
 config :logger, level: :warn
@@ -37,3 +38,6 @@ config :turn_junebug_expressway, :turn,
   event_path: System.get_env("TURN_OUTBOUND", "api/whatsapp/channel-id"),
   inbound_path: System.get_env("TURN_INBOUND", "v1/events"),
   token: System.get_env("TURN_TOKEN", "replaceme")
+
+config :turn_junebug_expressway, :rapidpro,
+  base_url: "https://test-rp.com/c/wa/channel-id/receive"

--- a/lib/turn_junebug_expressway/rapidpro_client.ex
+++ b/lib/turn_junebug_expressway/rapidpro_client.ex
@@ -1,11 +1,10 @@
-defmodule TurnJunebugExpressway.TurnClient do
+defmodule TurnJunebugExpressway.RapidproClient do
   use TurnJunebugExpressway.Behaviours.ClientBehaviour
 
   alias TurnJunebugExpresswayWeb.Utils
 
   def client() do
     default_middleware = [
-      {Tesla.Middleware.BaseUrl, Utils.get_env(:turn, :base_url)},
       Tesla.Middleware.JSON
     ]
 
@@ -22,26 +21,19 @@ defmodule TurnJunebugExpressway.TurnClient do
     Tesla.client(middleware)
   end
 
-  def post_event(client, body) do
-    client
-    |> do_post(Utils.get_env(:turn, :event_path), body)
+  def post_event(_client, _body) do
+    :ok
   end
 
+  @spec post_inbound(Tesla.Client.t(), any) :: :ok | {:error, any, Tesla.Env.t()}
   def post_inbound(client, body) do
     client
-    |> do_post(Utils.get_env(:turn, :inbound_path), body, [
-      {"authorization", "Bearer " <> Utils.get_env(:turn, :token)},
-      {"accept", "application/vnd.v1+json"}
-    ])
+    |> do_post(Utils.get_env(:rapidpro, :base_url), body)
   end
 
   def do_post(client, path, body, headers \\ []) do
     case client
-         |> post(path, body,
-           headers: [
-             {"x-turn-fallback-channel", "1"} | headers
-           ]
-         ) do
+         |> post(path, body, headers) do
       {:ok, %Tesla.Env{status: status}}
       when status in 200..299 ->
         :ok

--- a/lib/turn_junebug_expressway_web/utils.ex
+++ b/lib/turn_junebug_expressway_web/utils.ex
@@ -180,9 +180,4 @@ defmodule TurnJunebugExpresswayWeb.Utils do
         error
     end
   end
-
-  def version() do
-    {:ok, vsn} = :application.get_key(:my_app, :vsn)
-    List.to_string(vsn)
-  end
 end

--- a/lib/turn_junebug_expressway_web/utils.ex
+++ b/lib/turn_junebug_expressway_web/utils.ex
@@ -59,12 +59,12 @@ defmodule TurnJunebugExpresswayWeb.Utils do
     TurnJunebugExpressway.MessageEngine.publish_message(message)
   end
 
-  def get_event_timestamp(event) do
+  def get_event_timestamp(event, level \\ :millisecond) do
     event
     |> Map.get("timestamp")
     |> Timex.parse!("%Y-%m-%d %H:%M:%S.%f", :strftime)
     |> DateTime.from_naive!("Etc/UTC")
-    |> DateTime.to_unix(:millisecond)
+    |> DateTime.to_unix(level)
     |> to_string()
   end
 
@@ -119,7 +119,7 @@ defmodule TurnJunebugExpresswayWeb.Utils do
               "id" => Map.get(event, "user_message_id"),
               "recipient_id" => nil,
               "status" => status,
-              "timestamp" => get_event_timestamp(event)
+              "timestamp" => get_event_timestamp(event, :second)
             }
           ]
         })

--- a/test/turn_junebug_expressway/behaviours/rapidpro_client_behaviour_test.exs
+++ b/test/turn_junebug_expressway/behaviours/rapidpro_client_behaviour_test.exs
@@ -1,0 +1,28 @@
+defmodule TurnJunebugExpressway.Behaviours.RapidproClientBehaviourTest do
+  use TurnJunebugExpressway.DataCase
+
+  alias TurnJunebugExpressway.RapidproClient
+  alias TurnJunebugExpresswayWeb.Utils
+
+  import Tesla.Mock
+
+  describe "client behaviour" do
+    test "post_inbound/2 should post to rapidpro", %{} do
+      mock(fn %{
+                method: :post,
+                url: "https://test-rp.com/c/wa/channel-id/receive",
+                body: body,
+                headers: headers
+              } ->
+        assert Jason.decode!(body) == %{"some" => "inbound"}
+
+        assert headers == [{"content-type", "application/json"}]
+
+        json(%{})
+      end)
+
+      client = RapidproClient.client()
+      RapidproClient.post_inbound(client, %{"some" => "inbound"})
+    end
+  end
+end

--- a/test/turn_junebug_expressway/behaviours/turn_client_behaviour_test.exs
+++ b/test/turn_junebug_expressway/behaviours/turn_client_behaviour_test.exs
@@ -1,4 +1,4 @@
-defmodule TurnJunebugExpressway.Behaviours.ClientBehaviourTest do
+defmodule TurnJunebugExpressway.Behaviours.TurnClientBehaviourTest do
   use TurnJunebugExpressway.DataCase
 
   alias TurnJunebugExpressway.TurnClient
@@ -32,11 +32,12 @@ defmodule TurnJunebugExpressway.Behaviours.ClientBehaviourTest do
               } ->
         assert Jason.decode!(body) == %{"some" => "inbound"}
 
-        headers == [
-          {"authorization", "Bearer " <> Utils.get_env(:turn, :token)},
-          {"accept", "application/vnd.v1+json"},
-          {"x-turn-fallback-channel", "1"}
-        ]
+        assert headers == [
+                 {"x-turn-fallback-channel", "1"},
+                 {"authorization", "Bearer " <> Utils.get_env(:turn, :token)},
+                 {"accept", "application/vnd.v1+json"},
+                 {"content-type", "application/json"}
+               ]
 
         json(%{})
       end)

--- a/test/turn_junebug_expressway_web/utils_test.exs
+++ b/test/turn_junebug_expressway_web/utils_test.exs
@@ -68,7 +68,7 @@ defmodule TurnJunebugExpresswayWeb.UtilsTest do
     end
 
     test "send incoming message to turn", %{} do
-      body = %{
+      turn_body = %{
         "details" => %{
           "content" => "Hello my name is ...",
           "direction" => "inbound",
@@ -80,9 +80,23 @@ defmodule TurnJunebugExpresswayWeb.UtilsTest do
         "urn" => "+271234"
       }
 
+      rp_body = %{
+        "messages" => [
+          %{
+            "id" => "f74c4e6108d8418ab53dbcfd628242f3",
+            "from" => "+271234",
+            "text" => %{"body" => "Hello my name is ..."},
+            "timestamp" => "1572525144930",
+            "to" => "+271234",
+            "type" => "text"
+          }
+        ]
+      }
+
       TurnJunebugExpressway.Backends.ClientMock
-      |> expect(:client, fn -> :client end)
-      |> expect(:post_inbound, fn :client, ^body -> :ok end)
+      |> expect(:client, 2, fn -> :client end)
+      |> expect(:post_inbound, fn :client, ^turn_body -> :ok end)
+      |> expect(:post_inbound, fn :client, ^rp_body -> :ok end)
 
       event = %{
         "message_type" => "user_message",

--- a/test/turn_junebug_expressway_web/utils_test.exs
+++ b/test/turn_junebug_expressway_web/utils_test.exs
@@ -64,7 +64,6 @@ defmodule TurnJunebugExpresswayWeb.UtilsTest do
       TurnJunebugExpressway.Backends.ClientMock
       |> expect(:client, fn -> :client end)
       |> expect(:post_event, fn :client, new_body ->
-        IO.inspect(new_body)
         :ok
       end)
 

--- a/test/turn_junebug_expressway_web/utils_test.exs
+++ b/test/turn_junebug_expressway_web/utils_test.exs
@@ -23,7 +23,7 @@ defmodule TurnJunebugExpresswayWeb.UtilsTest do
             "id" => "f74c4e6108d8418ab53dbcfd628242f3",
             "recipient_id" => nil,
             "status" => "sent",
-            "timestamp" => "1572525144930"
+            "timestamp" => "1572525144"
           }
         ]
       }
@@ -43,6 +43,42 @@ defmodule TurnJunebugExpresswayWeb.UtilsTest do
         "timestamp" => "2019-10-31 12:32:24.930687",
         "transport_metadata" => %{},
         "user_message_id" => "f74c4e6108d8418ab53dbcfd628242f3",
+        "message_type" => "event"
+      }
+
+      :ok = Utils.handle_incoming_event(Jason.encode!(event))
+    end
+
+    test "sends event back to turn error from QA", %{} do
+      body = %{
+        "statuses" => [
+          %{
+            "id" => "f74c4e6108d8418ab53dbcfd628242f3",
+            "recipient_id" => nil,
+            "status" => "sent",
+            "timestamp" => "1572525144930"
+          }
+        ]
+      }
+
+      TurnJunebugExpressway.Backends.ClientMock
+      |> expect(:client, fn -> :client end)
+      |> expect(:post_event, fn :client, new_body ->
+        IO.inspect(new_body)
+        :ok
+      end)
+
+      event = %{
+        "transport_name" => "7f5f1869-d680-4202-910b-68d18a32c4fa",
+        "event_type" => "delivery_report",
+        "event_id" => "95e86bb8748a44709377773c53b2622c",
+        "timestamp" => "2020-01-22 07:35:34.251862",
+        "routing_metadata" => %{},
+        "message_version" => "20110921",
+        "helper_metadata" => %{},
+        "delivery_status" => "delivered",
+        "transport_metadata" => %{"smpp_delivery_status" => "DELIVERED"},
+        "user_message_id" => "16e42b66-03b7-4558-8a72-e9db481fdb4c",
         "message_type" => "event"
       }
 


### PR DESCRIPTION
The inbounds go to turn through the events api as a external message, those aren't forwarded to the webhooks.