### PR TITLE
Handle exit signal

### DIFF
--- a/lib/turn_junebug_expressway/message_engine.ex
+++ b/lib/turn_junebug_expressway/message_engine.ex
@@ -43,6 +43,7 @@ defmodule TurnJunebugExpressway.HttpPushEngine do
       {:ok, conn} ->
         # Get notifications when the connection goes down
         Process.monitor(conn.pid)
+        Process.flag(:trap_exit, true)
 
         {:ok, channel} = AMQP.Channel.open(conn)
 
@@ -91,6 +92,11 @@ defmodule TurnJunebugExpressway.HttpPushEngine do
   end
 
   def handle_info({:DOWN, _, :process, _pid, reason}, _) do
+    # Stop GenServer. Will be restarted by Supervisor.
+    {:stop, {:connection_lost, reason}, nil}
+  end
+
+  def handle_info({:EXIT, _pid, reason}, _) do
     # Stop GenServer. Will be restarted by Supervisor.
     {:stop, {:connection_lost, reason}, nil}
   end

--- a/test/turn_junebug_expressway/message_engine_test.exs
+++ b/test/turn_junebug_expressway/message_engine_test.exs
@@ -1,0 +1,18 @@
+defmodule TurnJunebugExpressway.HttpPushEngineTest do
+  use ExUnit.Case
+  alias TurnJunebugExpressway.HttpPushEngine
+
+  describe "start_link/1" do
+    test "restarts another process when something goes wrong" do
+      started_pid = Process.whereis(HttpPushEngine)
+
+      send(started_pid, {:EXIT, started_pid, :client_down})
+
+      :timer.sleep(100)
+
+      new_pid = Process.whereis(HttpPushEngine)
+
+      assert started_pid != new_pid
+    end
+  end
+end


### PR DESCRIPTION
According to the docs not properly handling the exit signal could cause the consumer to stop receiving messages.

https://hexdocs.pm/amqp/readme.html