### PR TITLE
Fix handling of client errors.

### DIFF
--- a/lib/turn_junebug_expressway/message_engine.ex
+++ b/lib/turn_junebug_expressway/message_engine.ex
@@ -122,8 +122,10 @@ defmodule TurnJunebugExpressway.HttpPushEngine do
     Basic.ack(channel, tag)
   end
 
-  def reject_failed_msg(channel, tag, redelivered, msg) do
+  def reject_failed_msg(channel, tag, redelivered, status, reason) do
     Basic.reject(channel, tag, requeue: not redelivered)
+
+    msg = "Error sending event: #{status} -> #{reason}"
 
     case redelivered do
       false -> IO.puts(msg)
@@ -145,7 +147,8 @@ defmodule TurnJunebugExpressway.HttpPushEngine do
           channel,
           tag,
           redelivered,
-          "Error sending event: #{status} -> #{reason}"
+          status,
+          reason
         )
     end
   end

--- a/test/turn_junebug_expressway/behaviours/turn_client_behaviour_test.exs
+++ b/test/turn_junebug_expressway/behaviours/turn_client_behaviour_test.exs
@@ -23,6 +23,46 @@ defmodule TurnJunebugExpressway.Behaviours.TurnClientBehaviourTest do
       TurnClient.post_event(client, %{"some" => "event"})
     end
 
+    test "post_event/2 should return string error in the correct format", %{} do
+      mock(fn %{
+                method: :post,
+                url: "https://testapp.turn.io/api/whatsapp/channel-id",
+                body: _body
+              } ->
+        %Tesla.Env{
+          body: "bad gateway",
+          method: :post,
+          status: 502
+        }
+      end)
+
+      client = TurnClient.client()
+      {:error, status, reason} = TurnClient.post_event(client, %{"some" => "event"})
+
+      assert status == 502
+      assert reason == "bad gateway"
+    end
+
+    test "post_event/2 should return map error in the correct format", %{} do
+      mock(fn %{
+                method: :post,
+                url: "https://testapp.turn.io/api/whatsapp/channel-id",
+                body: _body
+              } ->
+        body = %Tesla.Env{
+          body: %{"error" => "bad gateway", "test" => %{"nested" => "yes"}},
+          method: :post,
+          status: 502
+        }
+      end)
+
+      client = TurnClient.client()
+      {:error, status, reason} = TurnClient.post_event(client, %{"some" => "event"})
+
+      assert status == 502
+      assert reason == "error: bad gateway, test: nested: yes"
+    end
+
     test "post_inbound/2 should post to the fallback channel", %{} do
       mock(fn %{
                 method: :post,


### PR DESCRIPTION
It was trying to cast a map to a string before the reject causing the queue to stop consuming.